### PR TITLE
Fix outdated method call

### DIFF
--- a/dist/Themeplus/Template/layout/header/title.php
+++ b/dist/Themeplus/Template/layout/header/title.php
@@ -11,7 +11,7 @@
         <?php endif ?>
     </span>
     <?php if (! empty($description)): ?>
-        <small class="tooltip" title="<?= $this->text->markdownAttribute($description) ?>">
+        <small class="tooltip" title="<?= $this->text->markdown($description) ?>">
             <i class="fa fa-info-circle"></i>
         </small>
     <?php endif ?>


### PR DESCRIPTION
This was causing a crash in project details

https://git.mittelab.org/g5pw/kanboard-theme/commit/ea823cf0bfe7aa2968bf759834ea0ce6e9f02456?view=inline

Since this applies to a later/current version of a dependency, how best to handle this? Cater to new users, so that new downloads will fix the issue with the latest version of the dependency?